### PR TITLE
Add configurable tcp keepalive support to client and server

### DIFF
--- a/man/nbd-client.8.in.sgml
+++ b/man/nbd-client.8.in.sgml
@@ -66,6 +66,7 @@ manpage.1: manpage.sgml
       <arg>-systemd-mark</arg>
       <arg>-block-size <replaceable>block size</replaceable></arg>
       <arg>-timeout <replaceable>seconds</replaceable></arg>
+      <arg>-keepalive <replaceable>seconds</replaceable></arg>
       <arg>-name <replaceable>name</replaceable></arg>
       <arg>-certfile <replaceable>certfile</replaceable></arg>
       <arg>-keyfile <replaceable>keyfile</replaceable></arg>
@@ -164,6 +165,16 @@ manpage.1: manpage.sgml
 	  and will be part of kernel 2.6.24.</para>
 	</listitem>
       </varlistentry>
+      <varlistentry>
+        <term><option>-keepalive</option></term>
+	<replaceable>seconds</replaceable></option></term>
+        <term><option>-k</option></term>
+        <listitem>
+          <para>Specify the time (in seconds) the connection needs to remain idle
+           before TCP starts sending keepalive probes, and the time between each
+           subsequent keepalive probe.</para>
+        </listitem>
+       </varlistentry>
       <varlistentry>
 	<term><option>port</option></term>
 	<listitem>

--- a/man/nbd-server.1.in.sgml
+++ b/man/nbd-server.1.in.sgml
@@ -67,6 +67,7 @@ manpage.1: manpage.sgml
       <arg><option>-o <replaceable>section name</replaceable></option></arg>
       <arg><option>-C <replaceable>config file</replaceable></option></arg>
       <arg><option>-M <replaceable>max connections</replaceable></option></arg>
+      <arg><option>-k <replaceable>keepalive time</replaceable></option></arg>
       <arg><option>-V</option></arg>
       <arg><option>-d</option></arg>
     </cmdsynopsis>
@@ -222,6 +223,14 @@ manpage.1: manpage.sgml
 	<listitem>
 	  <para>Specify the maximum number of opened connections. If this
 	  parameter is not specified, no limit is set.</para>
+	</listitem>
+      </varlistentry>
+      <varlistentry>
+        <term><option>-k</option></term>
+	<listitem>
+	  <para>Specify the time (in seconds) the connection needs to remain idle
+          before TCP starts sending keepalive probes, and the time between each
+          subsequent keepalive probe.</para>
 	</listitem>
       </varlistentry>
       <varlistentry>


### PR DESCRIPTION
Enclosed is a COMPLETELY UNTESTED proof of concept patch to add tcp keep alive timing support for linux. Keepalives can be set on either the client or the server. They are envisaged to be more useful on the server. The idea here is to allow (for instance) a server to note a client has disappeared and wipe COW directories.

Note I explicitly set SO_KEEPALIVE on the server's accepted socket. We already set SO_KEEPALIVE (for reasons I'm unclear about) on the bind socket; I don't know whether POSIX guarantees this to be carried over to the accepted socket, and doubly don't know whether Linux will carry over the keepalive settings. Better do this explicitly I think. It's possible the other SO_KEEPALIVE setting could be removed. This was introduced over 10 years ago with a bug reference in SF which is now undiscoverable. I haven't removed this.

Note (once more) I have not tested this code - this is a proof of concept.


Flag -k N sets tcp keepalive to N seconds

Signed-off-by: Alex Bligh <alex@alex.org.uk>