### PR TITLE
client: fix size offset in parsing of response

### DIFF
--- a/nbd-client.c
+++ b/nbd-client.c
@@ -448,7 +448,7 @@ void ask_list(int sock) {
 void parse_sizes(char *buf, uint64_t *size, uint16_t *flags) {
 	memcpy(size, buf, sizeof(*size));
 	*size = ntohll(*size);
-	buf += sizeof(size);
+	buf += sizeof(*size);
 	memcpy(flags, buf, sizeof(*flags));
 	*flags = ntohs(*flags);
 


### PR DESCRIPTION
This fixes flags being set to bogus on 32-bit systems (armv7h),
where sizeof(*uint64_t) != sizeof(uint64_t).