### PR TITLE
nbd-client: set a proper timeout with netlink

### DIFF
--- a/nbd-client.c
+++ b/nbd-client.c
@@ -1113,6 +1113,9 @@ int main(int argc, char *argv[]) {
 		}
 	}
 
+	if (netlink && timeout == 0)
+		timeout = 1;
+
 	if (need_disconnect) {
 		if (netlink)
 			netlink_disconnect(nbddev);


### PR DESCRIPTION
With timeout set to zero nbd-client suffers connection timeouts,
so set a proper timeout.

Fixes #71