### PR TITLE
inetd mode fix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,4 +8,4 @@ compiler:
 install: 
   - sh .travis/before_install
 group: travis_latest
-script: ./autogen.sh && ./configure && make && make NBD_TEST_SILENT=1 check
+script: ./autogen.sh && ./configure --enable-syslog && make && make NBD_TEST_SILENT=1 check

--- a/nbd-server.c
+++ b/nbd-server.c
@@ -3538,19 +3538,6 @@ int main(int argc, char *argv[]) {
 
 	if(serve) {
 		g_array_append_val(servers, *serve);
-
-		if(strcmp(genconf.modernport, "0")==0) {
-#ifndef ISSERVER
-			err("inetd mode requires syslog");
-#endif
-			CLIENT* client = g_malloc(sizeof(CLIENT));
-			client->net = -1;
-			if(!commit_client(client, serve)) {
-				exit(EXIT_FAILURE);
-			}
-			mainloop_threaded(client);
-			return 0;
-		}
 	}
     
 	if(!servers || !servers->len) {
@@ -3594,5 +3581,18 @@ int main(int argc, char *argv[]) {
 #endif
 					));
 #endif
+
+	if((genconf.modernport != NULL) && strcmp(genconf.modernport, "0")==0) {
+#ifndef ISSERVER
+		err("inetd mode requires syslog");
+#endif
+		CLIENT* client = negotiate(0, servers, &genconf);
+		if(!client) {
+			exit(EXIT_FAILURE);
+		}
+		mainloop_threaded(client);
+		return 0;
+	}
+
 	serveloop(servers, &genconf);
 }

--- a/tests/run/Makefile.am
+++ b/tests/run/Makefile.am
@@ -4,7 +4,7 @@ else
 TLSSRC =
 endif
 TESTS_ENVIRONMENT=$(srcdir)/simple_test
-TESTS = cfg1 cfgmulti cfgnew cfgsize write flush integrity dirconfig list \
+TESTS = cfg1 cfgmulti cfgnew cfgsize write flush integrity dirconfig list inetd \
 	rowrite tree rotree unix integrityhuge handshake tls tlshuge tlswrongcert
 check_PROGRAMS = nbd-tester-client
 ## Various Automake versions don't play nice with files in parent
@@ -44,6 +44,7 @@ rowrite:
 tree:
 rotree:
 unix:
+inetd:
 handshake:
 tls:
 tlshuge:

--- a/tests/run/nbd-tester-client.c
+++ b/tests/run/nbd-tester-client.c
@@ -60,8 +60,6 @@ static gchar *cacertfile = NULL;
 static gchar *tlshostname = NULL;
 
 typedef enum {
-	CONNECTION_TYPE_NONE,
-	CONNECTION_TYPE_CONNECT,
 	CONNECTION_TYPE_INIT_PASSWD,
 	CONNECTION_TYPE_CLISERV,
 	CONNECTION_TYPE_FULL,
@@ -574,16 +572,12 @@ end:
 	return sock;
 }
 
-int setup_unix_connection(gchar * unixsock, gchar * name, CONNECTION_TYPE ctype,
-			  int *serverflags, int testflags)
+int setup_unix_connection(gchar * unixsock)
 {
 	struct sockaddr_un addr;
 	int sock;
 
 	sock = 0;
-	if (ctype < CONNECTION_TYPE_CONNECT) {
-		goto end;
-	}
 	if ((sock = socket(AF_UNIX, SOCK_STREAM, 0)) < 0) {
 		strncpy(errstr, strerror(errno), errstr_len);
 		goto err;
@@ -598,7 +592,6 @@ int setup_unix_connection(gchar * unixsock, gchar * name, CONNECTION_TYPE ctype,
 		strncpy(errstr, strerror(errno), errstr_len);
 		goto err_open;
 	}
-	sock = setup_connection_common(sock, name, ctype, serverflags, testflags);
 	goto end;
 err_open:
 	close(sock);
@@ -608,16 +601,13 @@ end:
 	return sock;
 }
 
-int setup_inet_connection(gchar * hostname, int port, gchar * name,
-			  CONNECTION_TYPE ctype, int *serverflags, int testflags)
+int setup_inet_connection(gchar * hostname, int port)
 {
 	int sock;
 	struct hostent *host;
 	struct sockaddr_in addr;
 
 	sock = 0;
-	if (ctype < CONNECTION_TYPE_CONNECT)
-		goto end;
 	if ((sock = socket(PF_INET, SOCK_STREAM, IPPROTO_TCP)) < 0) {
 		strncpy(errstr, strerror(errno), errstr_len);
 		goto err;
@@ -634,7 +624,6 @@ int setup_inet_connection(gchar * hostname, int port, gchar * name,
 		strncpy(errstr, strerror(errno), errstr_len);
 		goto err_open;
 	}
-	sock = setup_connection_common(sock, name, ctype, serverflags, testflags);
 	goto end;
 err_open:
 	close(sock);
@@ -642,21 +631,6 @@ err:
 	sock = -1;
 end:
 	return sock;
-}
-
-int setup_connection(gchar * hostname, gchar * unixsock, int port, gchar * name,
-		     CONNECTION_TYPE ctype, int *serverflags, int testflags)
-{
-	if (hostname != NULL) {
-		return setup_inet_connection(hostname, port, name, ctype,
-					     serverflags, testflags);
-	} else if (unixsock != NULL) {
-		return setup_unix_connection(unixsock, name, ctype,
-					     serverflags, testflags);
-	} else {
-		g_error("need a hostname or a unix domain socket!");
-		return -1;
-	}
 }
 
 int close_connection(int sock, CLOSE_TYPE type)
@@ -731,8 +705,7 @@ end:
 	return retval;
 }
 
-int oversize_test(gchar * hostname, gchar * unixsock, int port, char *name,
-		  int sock, char sock_is_open, char close_sock, int testflags)
+int oversize_test(char *name, int sock, char close_sock, int testflags)
 {
 	int retval = 0;
 	struct nbd_request req;
@@ -744,15 +717,13 @@ int oversize_test(gchar * hostname, gchar * unixsock, int port, char *name,
 	bool got_err;
 
 	/* This should work */
-	if (!sock_is_open) {
-		if ((sock =
-		     setup_connection(hostname, unixsock, port, name,
-				      CONNECTION_TYPE_FULL,
-				      &serverflags, testflags)) < 0) {
-			g_warning("Could not open socket: %s", errstr);
-			retval = -1;
-			goto err;
-		}
+	if ((sock =
+		 setup_connection_common(sock, name,
+				  CONNECTION_TYPE_FULL,
+				  &serverflags, testflags)) < 0) {
+		g_warning("Could not open socket: %s", errstr);
+		retval = -1;
+		goto err;
 	}
 	req.magic = htonl(NBD_REQUEST_MAGIC);
 	req.type = htonl(NBD_CMD_READ);
@@ -816,8 +787,7 @@ err:
 	return retval;
 }
 
-int handshake_test(gchar * hostname, gchar * unixsock, int port, char *name,
-		   int sock, char sock_is_open, char close_sock, int testflags)
+int handshake_test(char *name, int sock, char close_sock, int testflags)
 {
 	int retval = -1;
 	int serverflags = 0;
@@ -825,14 +795,12 @@ int handshake_test(gchar * hostname, gchar * unixsock, int port, char *name,
 	uint32_t tmp32 = 0;
 
 	/* This should work */
-	if (!sock_is_open) {
-		if ((sock =
-		     setup_connection(hostname, unixsock, port, name,
-				      CONNECTION_TYPE_FULL,
-				      &serverflags, testflags)) < 0) {
-			g_warning("Could not open socket: %s", errstr);
-			goto err;
-		}
+	if ((sock =
+		 setup_connection_common(sock, name,
+				  CONNECTION_TYPE_FULL,
+				  &serverflags, testflags)) < 0) {
+		g_warning("Could not open socket: %s", errstr);
+		goto err;
 	}
 
 	/* Intentionally throw an unknown option at the server */
@@ -899,8 +867,7 @@ err:
 	return retval;
 }
 
-int throughput_test(gchar * hostname, gchar * unixsock, int port, char *name,
-		    int sock, char sock_is_open, char close_sock, int testflags)
+int throughput_test(char *name, int sock, char close_sock, int testflags)
 {
 	long long int i;
 	char writebuf[1024];
@@ -924,20 +891,18 @@ int throughput_test(gchar * hostname, gchar * unixsock, int port, char *name,
 
 	memset(writebuf, 'X', 1024);
 	size = 0;
-	if (!sock_is_open) {
-		if ((sock =
-		     setup_connection(hostname, unixsock, port, name,
-				      CONNECTION_TYPE_FULL,
-				      &serverflags, testflags)) < 0) {
-			g_warning("Could not open socket: %s", errstr);
-			if(testflags & TEST_EXPECT_ERROR) {
-				g_message("Test failed, as expected");
-				retval = 0;
-			} else {
-				retval = -1;
-			}
-			goto err;
+	if ((sock =
+		 setup_connection_common(sock, name,
+				  CONNECTION_TYPE_FULL,
+				  &serverflags, testflags)) < 0) {
+		g_warning("Could not open socket: %s", errstr);
+		if(testflags & TEST_EXPECT_ERROR) {
+			g_message("Test failed, as expected");
+			retval = 0;
+		} else {
+			retval = -1;
 		}
+		goto err;
 	}
 	if ((testflags & TEST_FLUSH)
 	    && ((serverflags & (NBD_FLAG_SEND_FLUSH | NBD_FLAG_SEND_FUA))
@@ -1170,8 +1135,7 @@ uint64_t getrandomhandle(GHashTable * phash)
 	return handle;
 }
 
-int integrity_test(gchar * hostname, gchar * unixsock, int port, char *name,
-		   int sock, char sock_is_open, char close_sock, int testflags)
+int integrity_test(char *name, int sock, char close_sock, int testflags)
 {
 	struct nbd_reply rep;
 	fd_set rset;
@@ -1203,14 +1167,12 @@ int integrity_test(gchar * hostname, gchar * unixsock, int port, char *name,
 	GHashTable *handlehash = g_hash_table_new(g_int64_hash, g_int64_equal);
 
 	size = 0;
-	if (!sock_is_open) {
-		if ((sock =
-		     setup_connection(hostname, unixsock, port, name,
-				      CONNECTION_TYPE_FULL,
-				      &serverflags, testflags)) < 0) {
-			g_warning("Could not open socket: %s", errstr);
-			goto err;
-		}
+	if ((sock =
+		 setup_connection_common(sock, name,
+				  CONNECTION_TYPE_FULL,
+				  &serverflags, testflags)) < 0) {
+		g_warning("Could not open socket: %s", errstr);
+		goto err;
 	}
 
 	if ((serverflags & (NBD_FLAG_SEND_FLUSH | NBD_FLAG_SEND_FUA))
@@ -1720,14 +1682,14 @@ void handle_nonopt(char *opt, gchar ** hostname, long int *p)
 	}
 }
 
-typedef int (*testfunc) (gchar *, gchar *, int, char *, int, char, char, int);
+typedef int (*testfunc) (char *, int, char, int);
 
 int main(int argc, char **argv)
 {
 	gchar *hostname = NULL, *unixsock = NULL;
 	long int p = 0;
 	char *name = NULL;
-	int sock = 0;
+	int sock = -1;
 	int c;
 	int testflags = 0;
 	testfunc test = throughput_test;
@@ -1826,7 +1788,21 @@ int main(int argc, char **argv)
 	if (!tlshostname && hostname)
 		tlshostname = g_strdup(hostname);
 
-	if (test(hostname, unixsock, (int)p, name, sock, FALSE, TRUE, testflags)
+	if (hostname != NULL) {
+		sock = setup_inet_connection(hostname, p);
+	} else if (unixsock != NULL) {
+		sock = setup_unix_connection(unixsock);
+	} else {
+		g_error("need a hostname or a unix domain socket!");
+		return -1;
+	}
+
+	if (sock == -1) {
+		g_warning("Could not establish a connection: %s", errstr);
+		exit(EXIT_FAILURE);
+	}
+
+	if (test(name, sock, TRUE, testflags)
 	    < 0) {
 		g_warning("Could not run test: %s", errstr);
 		exit(EXIT_FAILURE);

--- a/tests/run/simple_test
+++ b/tests/run/simple_test
@@ -24,8 +24,6 @@ cleanup() {
 		if [ ! -z "$PID" ]
 		then
 			kill $PID || true
-		else
-			echo "E: Could not clean up!"
 		fi
 	fi
 	if [ -z "$cleanup" ]
@@ -292,6 +290,16 @@ EOF
 		PID=$!
 		sleep 1
 		./nbd-tester-client -N export1 -u ${tmpdir}/unix.sock
+		retval=$?
+		;;
+	*/inetd)
+		cat >${conffile} <<EOF
+[generic]
+	port = 0
+[export1]
+	exportname = ${tmpnam}
+EOF
+		./nbd-tester-client -N export1 -I -- ../../nbd-server -d -C ${conffile}
 		retval=$?
 		;;
 	*/handshake)


### PR DESCRIPTION
This series of patches restores proper functioning of the inetd mode in `nbd-server`. It also adds inetd mode testing to the test suite. Merging it will resolve #75.

Implementing the latter part required some fairly invasive refactoring of the test client. The testing functions are no longer involved with establishing the transport socket connection; they are handed the socket file descriptor already set up, although they still need to perform NBD protocol negotiation. The name of the protocol-negotiating function was kept as `setup_connection_common`, although it is no longer called from the `setup_*_connection` family of functions.