### PR TITLE
Don't make gnutls and libnl automagic

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -212,10 +212,25 @@ dnl 		;;
 dnl 	esac
 dnl fi
 
-PKG_CHECK_MODULES(GnuTLS, [gnutls >= 2.12.0],[HAVE_GNUTLS=1],[HAVE_GNUTLS=0])
-if test x$HAVE_GNUTLS = x1; then
-	AC_DEFINE(HAVE_GNUTLS, 1, [Define to 1 if you have a GnuTLS version of 2.12 or above])
+AC_ARG_WITH([gnutls],
+	[AS_HELP_STRING([--without-gnutls],
+		[do not use gnutls])],
+	[],
+	[with_gnutls=check]
+)
+if test "x$with_gnutls" != "xno"; then
+	PKG_CHECK_MODULES(GnuTLS, [gnutls >= 2.12.0],
+		[HAVE_GNUTLS=1
+		AC_DEFINE(HAVE_GNUTLS, 1, [Define to 1 if you have a GnuTLS version of 2.12 or above])],
+		[if test "x$with_gnutls" = "xyes"; then
+			AC_MSG_ERROR([--with-gnutls given but cannot find gnutls])
+		else
+			HAVE_GNUTLS=0
+			AC_DEFINE(HAVE_GNUTLS, 0)
+		fi]
+	)
 else
+	HAVE_GNUTLS=0
 	AC_DEFINE(HAVE_GNUTLS, 0)
 fi
 AM_CONDITIONAL([GNUTLS], [test "x$HAVE_GNUTLS" = "x1"])
@@ -294,13 +309,27 @@ AC_PREPROC_IFELSE(
 	[AC_MSG_RESULT([yes]); NEED_BSD_SOURCE=1])
 AC_DEFINE([NEED_BSD_SOURCE], $NEED_BSD_SOURCE, [Define to 1 if _BSD_SOURCE needs to be defined before certain inclusions])
 
-PKG_CHECK_MODULES(LIBNL3, libnl-genl-3.0 >= 3.1, [have_libnl3=yes], [have_libnl3=no])
-if test "${have_libnl3}" = "yes"
-then
-	AC_DEFINE(HAVE_NETLINK, 1, [Define to 1 if we have netlink support])
-	CFLAGS+=" $LIBNL3_CFLAGS"
-	LIBS+=" $LIBNL3_LIBS"
+AC_ARG_WITH([libnl],
+	[AS_HELP_STRING([--without-libnl],
+		[do not use libnl])],
+	[],
+	[with_libnl=check]
+)
+if test "x$with_libnl" != "xno"; then
+	PKG_CHECK_MODULES(LIBNL3, libnl-genl-3.0 >= 3.1,
+		[HAVE_NETLINK=1
+		AC_DEFINE(HAVE_NETLINK, 1, [Define to 1 if we have netlink support])
+		CFLAGS+=" $LIBNL3_CFLAGS"
+		LIBS+=" $LIBNL3_LIBS"],
+		[if test "x$with_libnl" = "xyes"; then
+			AC_MSG_ERROR([--with-libnl given but cannot find libnl])
+		else
+			HAVE_NETLINK=0
+			AC_DEFINE(HAVE_NETLINK, 0)
+		fi]
+	)
 else
+	HAVE_NETLINK=0
 	AC_DEFINE(HAVE_NETLINK, 0, [Define to 1 if we have netlink support])
 fi
 


### PR DESCRIPTION
Introduce --without-gnutls and --without-libnl configure options so that
users can disable gnutls/libnl even if the packages are available on the
system. The default is unchanged from before this patch. If no
--with(out)-* option has been given on the command line, the macro looks
for presence and uses the packages if found.