### PR TITLE
server: clean supplementary groups when setuid

### DIFF
--- a/nbd-server.c
+++ b/nbd-server.c
@@ -3470,6 +3470,7 @@ void dousers(const gchar *const username, const gchar *const groupname) {
 			str = g_strdup_printf("Invalid user name: %s", username);
 			err(str);
 		}
+		setgroups(0, NULL);
 		if(setuid(pw->pw_uid)<0) {
 			err("Could not set UID: %m");
 		}


### PR DESCRIPTION
When nbd-server drops privileges, it was leaving supplementary
groups untouched. As nbd-server was normally dropping from root,
nbd-server kept membership to root supplementary groups.

Signed-off-by: Luiz Angelo Daros de Luca <luizluca@gmail.com>

For example:

```
$ cat config
[generic]
    user = nobody
    group = nobody
    oldstyle = false
[export1]
        exportname = /dev/zero

$ sudo ./nbd-server -d --config-file config.example

$ ps -eo pid,comm,euser,egroup,supgrp | grep nbd
 5068 nbd-server      nobody   nogroup  root,socked
```

After the patch:

```
$ ps -eo pid,comm,euser,egroup,supgrp | grep nbd
 4958 nbd-server      nobody   nogroup  (null)
```