### PR TITLE
Don't set unset (zero) timeout in nbd-client when configuring via netlink

### DIFF
--- a/nbd-client.c
+++ b/nbd-client.c
@@ -120,7 +120,8 @@ static void netlink_configure(int index, int *sockfds, int num_connects,
 	NLA_PUT_U64(msg, NBD_ATTR_SIZE_BYTES, size64);
 	NLA_PUT_U64(msg, NBD_ATTR_BLOCK_SIZE_BYTES, blocksize);
 	NLA_PUT_U64(msg, NBD_ATTR_SERVER_FLAGS, flags);
-	NLA_PUT_U64(msg, NBD_ATTR_TIMEOUT, timeout);
+	if (timeout)
+		NLA_PUT_U64(msg, NBD_ATTR_TIMEOUT, timeout);
 
 	sock_attr = nla_nest_start(msg, NBD_ATTR_SOCKETS);
 	if (!sock_attr)


### PR DESCRIPTION
When we are operating as a daemon we ignore unset (zero) timeout in
set_timeout() and don't set it in kernel.
However, when operating in the netlink mode netlink_configure() will add
NBD_ATTR_TIMEOUT attribute unconditionally.

This means that in the default case of timeout being unset it was being set
to zero in the kernel which resulted in it triggering almost immediately
upon any I/O request.

Fix this by not appending the timeout attribute in netlink_configure() when
the timeout is unset.

This should fix #71 