### PR TITLE
correct shell variable assignment for libnl flags in configure(.ac)

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -319,8 +319,8 @@ if test "x$with_libnl" != "xno"; then
 	PKG_CHECK_MODULES(LIBNL3, libnl-genl-3.0 >= 3.1,
 		[HAVE_NETLINK=1
 		AC_DEFINE(HAVE_NETLINK, 1, [Define to 1 if we have netlink support])
-		CFLAGS+=" $LIBNL3_CFLAGS"
-		LIBS+=" $LIBNL3_LIBS"],
+		CFLAGS="$CFLAGS $LIBNL3_CFLAGS"
+		LIBS="$LIBS $LIBNL3_LIBS"],
 		[if test "x$with_libnl" = "xyes"; then
 			AC_MSG_ERROR([--with-libnl given but cannot find libnl])
 		else


### PR DESCRIPTION
With dash (0.5.9.1) linked to /bin/sh (actual shell should not matter), I get the following error on configure and a subsequent compliation failure because of lacking LIBS flags.

$ ./configure
(...)
checking for libnl-genl-3.0 >= 3.1... yes  
./configure: 14578: ./configure: CFLAGS+= -I/usr/include/libnl3: not found  
./configure: 14579: ./configure: LIBS+= -lnl-genl-3 -lnl-3: not found  
(...)

The diff below corrects the variable appending and compilation.