### PR TITLE
Don't listen on TCP if we are using a UNIX socket.

### DIFF
--- a/man/nbd-server.5.in.sgml
+++ b/man/nbd-server.5.in.sgml
@@ -356,6 +356,19 @@ manpage.1: manpage.sgml
 	</listitem>
       </varlistentry>
       <varlistentry>
+        <term><option>duallisten</option></term>
+	<listitem>
+	  <para>
+	    Optional; boolean
+	  </para>
+	  <para>
+	    If true, and <option>unixsock</option> is specified, the the
+	    server will listen on both the configured UNIX domain socket
+	    and any configured TCP or SDP socket.  Defaults to false.
+	  </para>
+	</listitem>
+      </varlistentry>
+      <varlistentry>
         <term><option>tlsprio</option></term>
 	<listitem>
 	  <para>Optional; string; default NORMAL:-VERS-TLS-ALL:+VERS-TLS1.2:%SERVER_PRECEDENCE</para>

--- a/man/nbd-server.5.in.sgml
+++ b/man/nbd-server.5.in.sgml
@@ -350,7 +350,8 @@ manpage.1: manpage.sgml
 	  <para>
 	    If specified, the server will listen on a UNIX domain socket
 	    with the specified name. Only newstyle negotiation is
-	    supported on UNIX domain sockets.
+	    supported on UNIX domain sockets. If a UNIX domain socket is,
+	    then the server will not listen for TCP connections.
 	  </para>
 	</listitem>
       </varlistentry>

--- a/nbd-server.c
+++ b/nbd-server.c
@@ -3367,18 +3367,19 @@ void setup_servers(GArray *const servers, const gchar *const modernaddr,
                    const gchar *const modernport, const gchar* unixsock) {
 	struct sigaction sa;
 
-        GError *gerror = NULL;
-        if (open_modern(modernaddr, modernport, &gerror) == -1) {
-                msg(LOG_ERR, "failed to setup servers: %s",
-                    gerror->message);
-                g_clear_error(&gerror);
-                exit(EXIT_FAILURE);
-	}
 	if(unixsock != NULL) {
 		GError* gerror = NULL;
 		if(open_unix(unixsock, &gerror) == -1) {
 			msg(LOG_ERR, "failed to setup servers: %s",
 					gerror->message);
+			g_clear_error(&gerror);
+			exit(EXIT_FAILURE);
+		}
+	} else {
+		GError *gerror = NULL;
+		if (open_modern(modernaddr, modernport, &gerror) == -1) {
+			msg(LOG_ERR, "failed to setup servers: %s",
+				gerror->message);
 			g_clear_error(&gerror);
 			exit(EXIT_FAILURE);
 		}

--- a/nbd-server.c
+++ b/nbd-server.c
@@ -3378,16 +3378,8 @@ void setup_servers(GArray *const servers, const gchar *const modernaddr,
 			g_clear_error(&gerror);
 			exit(EXIT_FAILURE);
 		}
-		if ((flags & F_DUAL_LISTEN) != 0) {
-			GError *gerror = NULL;
-			if (open_modern(modernaddr, modernport, &gerror) == -1) {
-				msg(LOG_ERR, "failed to setup servers: %s",
-					gerror->message);
-				g_clear_error(&gerror);
-				exit(EXIT_FAILURE);
-			}
-		}
-	} else {
+	}
+	if (((flags & F_DUAL_LISTEN) != 0) || (unixsock == NULL)) {
 		GError *gerror = NULL;
 		if (open_modern(modernaddr, modernport, &gerror) == -1) {
 			msg(LOG_ERR, "failed to setup servers: %s",


### PR DESCRIPTION
Currently, `nbd-server` will open a listening TCP socket even if it's been asked to use a UNIX domain socket.  This is inconsistent with typical behavior of applications which can use UNIX sockets, and may present a security risk on some systems.

This commit modifies this behavior so that use of a UNIX socket and other types of socket is mutually exclusive.  You can only listen on a regular (TCP or SDP) socket or a UNIX socket, but not both, with the presence of the `unixsock` option taking precedence over any other listener configuration.

This has a small potential to break some existing installations, though they are arguably depending on broken behavior to begin with.

The manual page is also updated to reflect this change.

----------

Minimally tested on Gentoo using a custom patch and the live ebuild (so, tested by applying this on top of the master branch and building the result), because I couldn't get autoconf to behave for some reason.