### PR TITLE
Use the real genconf.threads, not an uninitialized value

### DIFF
--- a/nbd-server.c
+++ b/nbd-server.c
@@ -3005,18 +3005,18 @@ static int get_index_by_servename(const gchar *const servename,
  * is unique among all other servers.
  *
  * @param servers an array of servers
+ * @param genconf a pointer to generic configuration
  * @return the number of new servers appended to the array, or -1 in
  *         case of an error
  **/
-static int append_new_servers(GArray *const servers, GError **const gerror) {
+static int append_new_servers(GArray *const servers, struct generic_conf *genconf, GError **const gerror) {
         int i;
         GArray *new_servers;
         const int old_len = servers->len;
         int retval = -1;
-        struct generic_conf genconf;
 
-        new_servers = parse_cfile(config_file_pos, &genconf, true, gerror);
-	g_thread_pool_set_max_threads(tpool, genconf.threads, NULL);
+        new_servers = parse_cfile(config_file_pos, genconf, true, gerror);
+        g_thread_pool_set_max_threads(tpool, genconf->threads, NULL);
         if (!new_servers)
                 goto out;
 
@@ -3127,7 +3127,7 @@ void serveloop(GArray* servers, struct generic_conf *genconf) {
                         is_sighup_caught = 0; /* Reset to allow catching
                                                * it again. */
 
-                        n = append_new_servers(servers, &gerror);
+                        n = append_new_servers(servers, genconf, &gerror);
                         if (n == -1)
                                 msg(LOG_ERR, "failed to append new servers: %s",
                                     gerror->message);


### PR DESCRIPTION
When HUP-signal is sent to nbd-server, append_new_servers()
function is executed and it looks up new "max_threads" value
from configuration.  Unfortunately, when such a value is not
provided by configuration, it uses an uninitialized memory value
for it.  Most often this is a big number such as 32612, and
no serious issues arise.  However, sometimes this might be zero,
depending on memory usage patterns, thus leading to max threads
value of 0 provided to g_thread_pool_set_max_threads(), meaning
that all nbd data sends are stopped.  In this situation all new
clients negotiate with server just fine, but they receive no data.

In this fix the real configuration data is used, or the default
of four threads if configuration does not provide a value.

(The issue can be worked around by setting "max_threads 4"
or some other sensible value in /etc/nbd-server/config
"[generic]"-section.)