### PR TITLE
rename err() function to avoid clashing with err() form C library

### DIFF
--- a/cliserv.h
+++ b/cliserv.h
@@ -76,7 +76,8 @@ int set_nonblocking(int fd, int nb);
 void setmysockopt(int sock);
 void err_nonfatal(const char *s);
 
-void err(const char *s) G_GNUC_NORETURN;
+void nbd_err(const char *s) G_GNUC_NORETURN;
+#define err(S) nbd_err(S)
 
 void logging(const char* name);
 

--- a/tests/code/Makefile.am
+++ b/tests/code/Makefile.am
@@ -6,16 +6,16 @@ AM_CFLAGS = @CFLAGS@ @GLIB_CFLAGS@
 AM_CPPFLAGS = -I$(top_srcdir)
 
 clientacl_SOURCES = clientacl.c punchdummy.c
-clientacl_LDADD = $(top_builddir)/libnbdsrv.la @GLIB_LIBS@
+clientacl_LDADD = $(top_builddir)/libnbdsrv.la $(top_builddir)/libcliserv.la @GLIB_LIBS@
 
 dup_SOURCES = dup.c punchdummy.c
-dup_LDADD = $(top_builddir)/libnbdsrv.la @GLIB_LIBS@
+dup_LDADD = $(top_builddir)/libnbdsrv.la $(top_builddir)/libcliserv.la @GLIB_LIBS@
 
 mask_SOURCES = mask.c punchdummy.c
-mask_LDADD = $(top_builddir)/libnbdsrv.la @GLIB_LIBS@
+mask_LDADD = $(top_builddir)/libnbdsrv.la $(top_builddir)/libcliserv.la @GLIB_LIBS@
 
 size_SOURCES = size.c punchdummy.c
-size_LDADD = $(top_builddir)/libnbdsrv.la @GLIB_LIBS@
+size_LDADD = $(top_builddir)/libnbdsrv.la $(top_builddir)/libcliserv.la @GLIB_LIBS@
 
 trim_SOURCES = trim.c
-trim_LDADD = $(top_builddir)/libnbdsrv.la @GLIB_LIBS@
+trim_LDADD = $(top_builddir)/libnbdsrv.la $(top_builddir)/libcliserv.la @GLIB_LIBS@


### PR DESCRIPTION
err() is a function available in the C library, so when static linking,
there is a clash at link time because the function is provided both by
nbd and the C library:
    http://autobuild.buildroot.org/results/aa8/aa8a1ac35a93e1c8b9fddbc2b5d66ecaa921f31e/build-end.log

Fix that by renaming err() to nbd_err() and providing a small macro
wrapper to avoid touching the many call sites.

Signed-off-by: "Yann E. MORIN" <yann.morin.1998@free.fr>
[Retrieved from:
https://git.buildroot.net/buildroot/tree/package/nbd/0001-avoid-name-clashing.patch]
Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>