### PR TITLE
nbd-client: Support a pre-initialized connection

### DIFF
--- a/man/nbd-client.8.in.sgml
+++ b/man/nbd-client.8.in.sgml
@@ -66,7 +66,9 @@ manpage.1: manpage.sgml
       <arg>-nonetlink</arg>
       <arg>-systemd-mark</arg>
       <arg>-readonly</arg>
+      <arg>-preinit</arg>
       <arg>-block-size <replaceable>block size</replaceable></arg>
+      <arg>-size <replaceable>bytes</replaceable></arg>
       <arg>-timeout <replaceable>seconds</replaceable></arg>
       <arg>-name <replaceable>name</replaceable></arg>
       <arg>-certfile <replaceable>certfile</replaceable></arg>
@@ -86,7 +88,9 @@ manpage.1: manpage.sgml
       <arg>-nonetlink</arg>
       <arg>-systemd-mark</arg>
       <arg>-readonly</arg>
+      <arg>-preinit</arg>
       <arg>-block-size <replaceable>block size</replaceable></arg>
+      <arg>-size <replaceable>bytes</replaceable></arg>
       <arg>-timeout <replaceable>seconds</replaceable></arg>
       <arg>-name <replaceable>name</replaceable></arg>
     </cmdsynopsis>
@@ -267,6 +271,18 @@ manpage.1: manpage.sgml
 	</listitem>
       </varlistentry>
       <varlistentry>
+        <term><option>-preinit</option></term>
+        <term><option>-P</option></term>
+        <listitem>
+          <para>When this option is specified, &dhpackage; will skip
+            the usual negotiation with the server, and hand the socket
+            to the kernel immediately after connecting. Only use this
+            when connecting to specialized NBD servers specifically
+            designed for it. This requires specifying the size of the
+            device via the -B option, and does not support TLS.</para>
+        </listitem>
+      </varlistentry>
+      <varlistentry>
         <term><option>-readonly</option></term>
         <term><option>-R</option></term>
         <listitem>
@@ -274,6 +290,16 @@ manpage.1: manpage.sgml
             kernel to treat the device as read-only, even if the server
             would allow writes.</para>
         </listitem>
+      </varlistentry>
+      <varlistentry>
+	<term><option>-size <replaceable>bytes</replaceable></option></term>
+	<term><option>-B <replaceable>bytes</replaceable></option></term>
+	<listitem>
+          <para>Force the device size to the specified number of bytes,
+            rather than using the value from server negotiation. Must
+            be a multiple of the block size. If using preinit (-P) to
+            skip negotiation, this option is required.</para>
+	</listitem>
       </varlistentry>
       <varlistentry>
         <term><option>-sdp</option></term>

--- a/man/nbd-client.8.in.sgml
+++ b/man/nbd-client.8.in.sgml
@@ -65,6 +65,7 @@ manpage.1: manpage.sgml
       <arg>-nofork</arg>
       <arg>-nonetlink</arg>
       <arg>-systemd-mark</arg>
+      <arg>-readonly</arg>
       <arg>-block-size <replaceable>block size</replaceable></arg>
       <arg>-timeout <replaceable>seconds</replaceable></arg>
       <arg>-name <replaceable>name</replaceable></arg>
@@ -84,6 +85,7 @@ manpage.1: manpage.sgml
       <arg>-nofork</arg>
       <arg>-nonetlink</arg>
       <arg>-systemd-mark</arg>
+      <arg>-readonly</arg>
       <arg>-block-size <replaceable>block size</replaceable></arg>
       <arg>-timeout <replaceable>seconds</replaceable></arg>
       <arg>-name <replaceable>name</replaceable></arg>
@@ -263,6 +265,15 @@ manpage.1: manpage.sgml
 	    connection ever drops unexpectedly due to a lost
 	    server or something similar.</para>
 	</listitem>
+      </varlistentry>
+      <varlistentry>
+        <term><option>-readonly</option></term>
+        <term><option>-R</option></term>
+        <listitem>
+          <para>When this option is specified, &dhpackage; will tell the
+            kernel to treat the device as read-only, even if the server
+            would allow writes.</para>
+        </listitem>
       </varlistentry>
       <varlistentry>
         <term><option>-sdp</option></term>


### PR DESCRIPTION
For debugging purposes, sometimes I'd find it helpful if nbd-client could skip the handshake, and just send the socket directly to the kernel after connecting. Would it be possible to add an option to skip the handshake negotiation?