### PR TITLE
nbd-server: fix bug in authentication for v6-mapped IPv4 addresses

### DIFF
--- a/nbdsrv.c
+++ b/nbdsrv.c
@@ -91,6 +91,7 @@ bool address_matches(const char* mask, const struct sockaddr* addr, GError** err
 				/* Map res to IPv6 for comparison */
 				memcpy(&ipv4_mapped[IPV4_MAP_PREFIX], &(((struct sockaddr_in*)(res->ai_addr))->sin_addr), 4);
 				byte_t = &ipv4_mapped[0];
+				len_left += IPV4_MAP_PREFIX * 8;
 				break;
 			}
 		}

--- a/tests/code/clientacl.c
+++ b/tests/code/clientacl.c
@@ -27,10 +27,13 @@ bool do_test(char* address, char* netmask) {
 	}
 	tmp = res;
 	while(res) {
-		printf("Found %s\n", inet_ntop(res->ai_family,
-					   &(((struct sockaddr_in*)res->ai_addr)->sin_addr),
-					       buf,
-					       res->ai_addrlen));
+		if((err = getnameinfo((struct sockaddr*)res->ai_addr, res->ai_addrlen, buf,
+                                       sizeof (buf), NULL, 0, NI_NUMERICHOST))) {
+                        fprintf(stderr, "E: %s\n", gai_strerror(err));
+                        exit(EXIT_FAILURE);
+
+		printf("Found %s\n", buf);
+
 		if(address_matches(netmask, (struct sockaddr*)res->ai_addr, NULL)) {
 			printf("Yes!\n");
 			freeaddrinfo(tmp);
@@ -50,6 +53,12 @@ int main(void) {
 	}
 	if(!do_test("192.168.0.1", "192.168.0.1/24")) {
 		return 1;
+	}
+	if(!do_test("::ffff:192.168.200.1", "192.168.200.1/24")) {
+                return 1;
+        }
+        if(do_test("::ffff:192.168.200.1", "192.168.100.1/24")) {
+                return 1;
 	}
 	if(do_test("192.168.200.1", "192.168.0.0/24")) {
 		return 1;


### PR DESCRIPTION
For v6-mapped address authentication, when comparing the client IP address
with the address in the authentication file, we should skip the first
12 identical prefixes and compare the real IP address.

This Fixes: #137
