### PR TITLE
nbd-server: Add option to not daemonize main process

### DIFF
--- a/man/nbd-server.1.in.sgml
+++ b/man/nbd-server.1.in.sgml
@@ -68,6 +68,7 @@ manpage.1: manpage.sgml
       <arg><option>-C <replaceable>config file</replaceable></option></arg>
       <arg><option>-M <replaceable>max connections</replaceable></option></arg>
       <arg><option>-V</option></arg>
+      <arg><option>-n</option></arg>
       <arg><option>-d</option></arg>
     </cmdsynopsis>
   </refsynopsisdiv>
@@ -231,9 +232,18 @@ manpage.1: manpage.sgml
 	</listitem>
       </varlistentry>
       <varlistentry>
+        <term><option>-n</option></term>
+        <listitem>
+          <para>Do not daemonize the main process. In contrast
+          to <option>-d</option>, this still allows to fork the
+          serving process for a client from the main process.</para>
+        </listitem>
+      </varlistentry>
+      <varlistentry>
         <term><option>-d</option></term>
 	<listitem>
-	  <para>Do not fork. Useful for debugging.</para>
+	  <para>Do not fork. Useful for debugging.
+	  Implies <option>-n</option>.</para>
 	</listitem>
       </varlistentry>
       <varlistentry>


### PR DESCRIPTION
This pull requests addresses #132 by adding the new option -n/--nodaemon to nbd-server. When set, it keeps the main process in the foreground, while still allowing to fork the serving process for a client. Functionally, it should be equivalent to providing NODAEMON to the preprocessor.

The commit also fixes a minor inaccuracy in the usage() function, which wrongly stated that the long option of -M is --max-connections (with trailing 's'). While conceptually unrelated, I've still included it as it's a trivial fix; let me know in case I should take it out.

I should note that I'm completely new to the nbd codebase, thus hoping I didn't miss anything relevant. Did some manual testing though (using live ebuild on Gentoo + patch to build it and then playing around with a few client connections) and it seems to work fine.