### PR TITLE
Avoid sporadic race condition due to parallel make

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -44,6 +44,7 @@ endif
 endif
 
 libnbdclt_la_SOURCES = nbdtab_parser.tab.h nbdtab_parser.y nbdtab_lexer.l nbdclt.h
+BUILT_SOURCES = nbdtab_parser.tab.h
 
 nbd-client.c: $(builddir)/nbdtab_parser.tab.h
 nbdtab_parser.tab.h: $(srcdir)/nbdtab_parser.y


### PR DESCRIPTION
nbdtab_lexer.l includes nbdtab_parser.tab.h, which in turn is dynamically generated during the build from nbdtab_parser.y. Specifying nbdtab_parser.tab.h in BUILT_SOURCES avoids a potential race condition where parallel make can fail if nbdtab_lexer.l is processed before nbdtab_parser.tab.h has been created.

Fixes: #140