### PR TITLE
Fix server array reference counting.

### DIFF
--- a/nbd-server.c
+++ b/nbd-server.c
@@ -765,6 +765,14 @@ GArray* do_cfile_dir(gchar* dir, struct generic_conf *const genconf, GError** e)
 }
 
 /**
+ * To be called by GArray clearing function.
+ * @param server pointer to server element
+ */
+static void serve_clear_element(SERVER **server) {
+	serve_dec_ref(*server);
+}
+
+/**
  * Parse the config file.
  *
  * @param f the name of the config file
@@ -867,7 +875,7 @@ GArray* parse_cfile(gchar* f, struct generic_conf *const genconf, bool expect_ge
 	cfile = g_key_file_new();
 	retval = g_array_new(FALSE, TRUE, sizeof(SERVER*));
 	if(expect_generic) {
-		g_array_set_clear_func(retval, (GDestroyNotify)serve_dec_ref);
+		g_array_set_clear_func(retval, (GDestroyNotify)serve_clear_element);
 	}
 	if(!g_key_file_load_from_file(cfile, f, G_KEY_FILE_KEEP_COMMENTS |
 			G_KEY_FILE_KEEP_TRANSLATIONS, &err)) {

--- a/nbd-server.c
+++ b/nbd-server.c
@@ -3179,6 +3179,7 @@ static int append_new_servers(GArray *const servers, struct generic_conf *gencon
                 if (new_server->servename
                     && -1 == get_index_by_servename(new_server->servename,
                                                     servers)) {
+			serve_inc_ref(new_server);
 			g_array_append_val(servers, new_server);
                 }
         }


### PR DESCRIPTION
The function given to g_array_set_clear_func() for clearing server arrays gets a pointer to server pointer as a parameter instead of simply pointer to server structure.  This change adds a wrapper function removing one level of indirection. Before this change, when arrays are freed, the serve_dec_ref() would decrement random stuff in memory and rarely call free() to some random memory address, crashing nbd-server.