### PR TITLE
fix missing -F short-option for certfile

### DIFF
--- a/nbd-client.c
+++ b/nbd-client.c
@@ -896,11 +896,14 @@ void disconnect(char* device) {
 	close(nbd);
 }
 
+static const char *short_opts = "-B:b:c:d:gH:hlnN:PpRSst:uVx"
 #if HAVE_NETLINK
-static const char *short_opts = "-A:B:b:c:C:d:gH:hK:LlnN:PpRSst:uVx";
-#else
-static const char *short_opts = "-A:B:b:c:C:d:gH:hK:lnN:PpRSst:uVx";
+	"L"
 #endif
+#if HAVE_GNUTLS
+	"A:C:F:K:"
+#endif
+	;
 
 int main(int argc, char *argv[]) {
 	char* port=NBD_DEFAULT_PORT;


### PR DESCRIPTION
in commit 1b8615, the `-F` short-option was accidentally refactored out of the codebase, so that only the long-option for `-certfile` would work. This commit restores the `-F` short-option, as well as conditionally populating the `short_opts` string based on compilation-options for `NETLINK` and `GNUTLS`