### PR TITLE
Fix the "disabled" case of enable_manpages

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -328,7 +328,7 @@ AC_MSG_CHECKING([whether man pages are requested])
 AC_ARG_ENABLE([manpages],
 	AS_HELP_STRING([--disable-manpages], [Do not install man pages]),
 	[],
-	[: m4_divert_text([DEFAULTS], [enable_manpages=check])]
+	[enable_manpages=check]
 )
 AC_MSG_RESULT([$enable_manpages])
 
@@ -337,9 +337,14 @@ AS_IF([test "x$enable_manpages" != "xno"], [
 	])
 AS_IF([test "x$enable_manpages" = "xyes" -a "x$DB2M" = "x"], [
        AC_MSG_ERROR([docbook2man not found, but is required to build manpages])
-	],
-      [test "x$DB2M" != "x"], [enable_manpages=yes],
-       [AC_MSG_ERROR([don't know what to do here])])
+	])
+if test "x$enable_manpages" = "xcheck"; then
+	if test "x$DB2M" = "x"; then
+		enable_manpages=no
+	else
+		enable_manpages=yes
+	fi
+fi
 AC_MSG_CHECKING([whether to build manpages])
 AC_MSG_RESULT([$enable_manpages])
 


### PR DESCRIPTION
Currently, running `configure --disable-manpages` while `docbook2man` *is* installed results in the error "don't know what to do here" when it should disable building of manpages (I ran into this when attempting a build on Ubuntu jammy, finding the manpages didn't want to build, and thinking "I'll just disable that for the moment", and then finding I couldn't disable it :).

There also appears to be a missing conditional at the start of the line; there's closing un-matched ]) at the end of the line. Still, at this point the check can be done in pure shell, no need for AC macros. I've also removed the confusing `m4_divert_text` call on the check case. Not sure why that was there, but it appears unnecessary.