### PR TITLE
Set sensible default for port

### DIFF
--- a/nbd-client.c
+++ b/nbd-client.c
@@ -754,6 +754,7 @@ bool get_from_config(char* cfgname, char** name_ptr, char** dev_ptr, char** host
 	cur_client = calloc(sizeof(CLIENT), 1);
 	cur_client->bs = 512;
 	cur_client->nconn = 1;
+	cur_client->port = NBD_DEFAULT_PORT;
 	yyin = fopen(SYSCONFDIR "/nbdtab", "r");
 	yyout = fopen("/dev/null", "w");
 


### PR DESCRIPTION
Commit 915444bc0b8a931d32dfb755542f4bd1d37f1449 introduced a regression whereby an entry in *nbdtab* with no port specification was read as wanting port "0" rather than the default "10809".

I attempted to run the current master branch within a test VM but could not get it to connect to the test server using configuration stored in *nbdtab*. However, using command line options worked happily; `strace` of the process eventually confirmed it was attempting to connect to port 0 rather than the expected port 10809 which pointed to a configuration parsing error.