### PR TITLE
fix clang 14 warnings in nbd-server.c

### DIFF
--- a/nbd-server.c
+++ b/nbd-server.c
@@ -2882,7 +2882,7 @@ static void handle_normal_read(CLIENT *client, struct nbd_request *req)
 	} else {
 		ctx->is_structured = 0;
 	}
-	if(req->type & NBD_CMD_FLAG_DF != 0) {
+	if((req->type & NBD_CMD_FLAG_DF) != 0) {
 		ctx->df = 1;
 	}
 	if(ctx->is_structured && ctx->df && req->len > (1 << 20)) {
@@ -3312,7 +3312,7 @@ static int handle_childname(GArray* servers, int socket)
 				break;
 		}
 	}
-	if (len >= ULONG_MAX - 1) {
+	if (len >= UINT32_MAX - 1) {
 		err_nonfatal("Value out of range");
 		return -1;
 	}


### PR DESCRIPTION
Clang 14 on macOS 12.7.4 (and I guess also newer versions) emits these warnings when compiling nbd-server.c:

```
  CC       nbd_server-nbd-server.o
nbd-server.c:2885:15: warning: & has lower precedence than !=; != will be evaluated first [-Wparentheses]
        if(req->type & NBD_CMD_FLAG_DF != 0) {
                     ^~~~~~~~~~~~~~~~~~~~~~
nbd-server.c:2885:15: note: place parentheses around the '!=' expression to silence this warning
        if(req->type & NBD_CMD_FLAG_DF != 0) {
                     ^ ~~~~~~~~~~~~~~~~~~~~
nbd-server.c:2885:15: note: place parentheses around the & expression to evaluate it first
        if(req->type & NBD_CMD_FLAG_DF != 0) {
           ~~~~~~~~~~^~~~~~~~~~~~~~~~~
nbd-server.c:3315:10: warning: result of comparison of constant 18446744073709551614 with expression of type 'uint32_t' (aka 'unsigned int') is always false [-Wtautological-constant-out-of-range-compare]
        if (len >= ULONG_MAX - 1) {
            ~~~ ^  ~~~~~~~~~~~~~
```

This commit will address these 2 warnings and fix the code.