### PR TITLE
Fix nbd-server infinite loop for TLS

### DIFF
--- a/nbd-server.c
+++ b/nbd-server.c
@@ -333,6 +333,8 @@ static int readit_tls(gnutls_session_t s, void *buf, size_t len) {
 			m = g_strdup_printf("could not receive data: %s", gnutls_strerror(res));
 			err_nonfatal(m);
 			return -1;
+		} else if(res == 0) {
+			nbd_err("TLS End of data: Remote connection closed.");
 		} else {
 			len -= res;
 			buf += res;


### PR DESCRIPTION
When the nbd-client disconnects from a TLS connection, the gnutls_record_recv function will return a zero value. Due to a faulty/missing check, this causes the readit_tls call to enter an infinite loop, with all terrible consequences that this has. This is a very problematic bug that causes a full CPU usage, and is only treatable by killing the nbd-server.

This fix adds the missing check and an appropriate message that terminates the forked server child graceously.

