### PR TITLE
nbd-server: drop the double-fork

### DIFF
--- a/nbd-server.c
+++ b/nbd-server.c
@@ -3816,12 +3816,6 @@ void daemonize() {
         if(dup2(2, newfd) < 0) {
                 err("dup2 stderr");
         }
-        child=fork();
-        if(child < 0) {
-                err("fork");
-        } else if(child > 0) {
-                exit(EXIT_SUCCESS);
-        }
 	FILE*pidf=fopen(pidfname, "w");
 	if(pidf) {
 		fprintf(pidf,"%d\n", (int)getpid());


### PR DESCRIPTION
... as this breaks as systemd service: This is of type 'forking', so the (first) fork becomes the main and controlling process. The second fork makes the main process exit, and the service is stopped.

Closes: https://github.com/NetworkBlockDevice/nbd/issues/182