### PR TITLE
undefined symbol persist_mode_main when HAVE_NETLINK=0

### DIFF
--- a/nbd-client.c
+++ b/nbd-client.c
@@ -1545,9 +1545,11 @@ int main(int argc, char *argv[]) {
 		netlink_configure(index, sockfds, flags, identifier);
 		
 		/* If persist mode is enabled, start the monitoring loop */
+#if HAVE_NETLINK
 		if (cur_client->persist_mode) {
 			return persist_mode_main(index, sockfds, flags);
 		}
+#endif
 		
 		return 0;
 	}


### PR DESCRIPTION
Reproducable when manually setting HAVE_NETLINK to 0 in config.h:

```
nbd-client.c: In function ‘main’:
nbd-client.c:1549:32: error: implicit declaration of function ‘persist_mode_main’ [-Wimplicit-function-declaration]
 1549 |                         return persist_mode_main(index, sockfds, flags);
      |                                ^~~~~~~~~~~~~~~~~
```