### PR TITLE
move #includes from headers to .c files, remove unnecessary #includes.

### DIFF
--- a/buffer.c
+++ b/buffer.c
@@ -27,6 +27,8 @@ OTHER DEALINGS IN THE SOFTWARE.
 #include <sys/types.h>
 
 #include "buffer.h"
+#include <stdlib.h>
+
 
 struct buffer
 {

--- a/buffer.h
+++ b/buffer.h
@@ -25,7 +25,7 @@ OTHER DEALINGS IN THE SOFTWARE.
 #ifndef __TLSPROXY_BUFFERS_H
 #define __TLSPROXY_BUFFERS_H
 
-#include <stdlib.h>
+//#include <stdlib.h>
 #include <sys/types.h>
 
 typedef struct buffer buffer_t;

--- a/cliserv.c
+++ b/cliserv.c
@@ -1,4 +1,5 @@
 #include <config.h>
+#include <errno.h>
 #include <fcntl.h>
 #include <stdio.h>
 #include <syslog.h>

--- a/cliserv.h
+++ b/cliserv.h
@@ -9,14 +9,14 @@
    Send 128 bytes of zeros (reserved for future use)
  */
 
-#include <errno.h>
+// #include <errno.h>
 #include <string.h>
 #include <netdb.h>
 #include <netinet/tcp.h>
 #include <netinet/in.h>
 #include <stdlib.h>
 
-#include "nbd.h"
+//#include "nbd.h"
 
 #ifndef HAVE_FDATASYNC
 #define fdatasync(arg) fsync(arg)

--- a/nbd-client.c
+++ b/nbd-client.c
@@ -19,17 +19,18 @@
  */
 
 #include "config.h"
-#include "lfs.h"
+// #include "lfs.h"
+#include "nbd.h"
 
 #include <sys/ioctl.h>
 #include <sys/socket.h>
 #include <sys/un.h>
 #include <sys/types.h>
 #include <unistd.h>
-#include <netinet/tcp.h>
+// #include <netinet/tcp.h>
 #include <netinet/in.h>
 #include <netdb.h>
-#include "netdb-compat.h"
+// #include "netdb-compat.h"
 #include <inttypes.h>
 #include <stdio.h>
 #include <fcntl.h>
@@ -39,12 +40,12 @@
 #include <sys/mman.h>
 #include <signal.h>
 #include <errno.h>
-#include <getopt.h>
+// #include <getopt.h>
 #include <stdarg.h>
 #include <stdbool.h>
 #include <time.h>
 
-#include <linux/ioctl.h>
+// #include <linux/ioctl.h>
 
 #if HAVE_NETLINK
 #include "nbd-netlink.h"

--- a/nbd-debug.h
+++ b/nbd-debug.h
@@ -5,7 +5,7 @@
 #ifdef DODBG
 #define DEBUG(...) printf(__VA_ARGS__)
 #else
-#define DEBUG(...)
+#define DEBUG(...) do{}while(0)
 #endif
 #ifndef PACKAGE_VERSION
 #define PACKAGE_VERSION ""

--- a/nbd-server.c
+++ b/nbd-server.c
@@ -78,11 +78,11 @@
 #ifdef HAVE_SYS_UIO_H
 #include <sys/uio.h>
 #endif
-#include <sys/param.h>
+// #include <sys/param.h>
 #include <signal.h>
 #include <errno.h>
 #include <libgen.h>
-#include <netinet/tcp.h>
+// #include <netinet/tcp.h>
 #include <netinet/in.h>
 #include <netdb.h>
 #include <syslog.h>
@@ -98,8 +98,8 @@
 #if HAVE_BLKDISCARD
 #include <linux/fs.h>
 #endif
-#include <arpa/inet.h>
-#include <strings.h>
+// #include <arpa/inet.h>
+// #include <strings.h>
 #include <dirent.h>
 #ifdef HAVE_SYS_DIR_H
 #include <sys/dir.h>
@@ -111,7 +111,7 @@
 #include <pwd.h>
 #include <grp.h>
 #include <dirent.h>
-#include <ctype.h>
+// #include <ctype.h>
 #include <inttypes.h>
 
 #include <glib.h>
@@ -120,7 +120,7 @@
 #define MY_NAME "nbd_server"
 #include "cliserv.h"
 #include "nbd-debug.h"
-#include "netdb-compat.h"
+// #include "netdb-compat.h"
 #include "backend.h"
 #include "treefiles.h"
 #include "nbd-helper.h"
@@ -379,9 +379,8 @@ static void socket_read(CLIENT* client, void *buf, size_t len) {
  * @param bufsiz the size of the buffer
  **/
 static inline void consume(CLIENT* c, size_t len, void * buf, size_t bufsiz) {
-	size_t curlen;
 	while (len>0) {
-		curlen = (len>bufsiz)?bufsiz:len;
+        const size_t curlen = (len>bufsiz)?bufsiz:len;
 		socket_read(c, buf, curlen);
 		len -= curlen;
 	}
@@ -555,7 +554,7 @@ SERVER* cmdline(int argc, char *argv[], struct generic_conf *genconf) {
 	int i=0;
 	int nonspecial=0;
 	int c;
-	struct option long_options[] = {
+    const struct option long_options[] = {
 		{"read-only", no_argument, NULL, 'r'},
 		{"multi-file", no_argument, NULL, 'm'},
 		{"copy-on-write", no_argument, NULL, 'c'},

--- a/nbd-server.c
+++ b/nbd-server.c
@@ -279,17 +279,17 @@ typedef struct {
  * Configuration file values of the "generic" section
  **/
 struct generic_conf {
-        gchar *user;        /**< user we run the server as    */
-        gchar *group;       /**< group we run running as      */
-        gchar *modernaddr;  /**< address of the modern socket */
-        gchar *modernport;  /**< port of the modern socket    */
-        gchar *unixsock;	   /**< file name of the unix domain socket */
-	gchar *certfile;        /**< certificate file             */
-	gchar *keyfile;         /**< key file                     */
-	gchar *cacertfile;      /**< CA certificate file          */
-    gchar *tlsprio;         /**< TLS priority string	  */
-        gint flags;         /**< global flags                 */
-	gint threads;		/**< maximum number of parallel threads we want to run */
+	gchar *user;        /**< user we run the server as    */
+	gchar *group;       /**< group we run running as      */
+	gchar *modernaddr;  /**< address of the modern socket */
+	gchar *modernport;  /**< port of the modern socket    */
+	gchar *unixsock;    /**< file name of the unix domain socket */
+	gchar *certfile;    /**< certificate file             */
+	gchar *keyfile;     /**< key file                     */
+	gchar *cacertfile;  /**< CA certificate file          */
+	gchar *tlsprio;     /**< TLS priority string          */
+	gint flags;         /**< global flags                 */
+	gint threads;       /**< maximum number of parallel threads we want to run */
 };
 
 #if HAVE_GNUTLS
@@ -1190,7 +1190,7 @@ int get_filepos(CLIENT *client, off_t a, int* fhandle, off_t* foffset, size_t* m
  * @param fua Flag to indicate 'Force Unit Access'
  * @return The number of bytes actually written, or -1 in case of an error
  **/
-ssize_t rawexpwrite(off_t a, char *buf, size_t len, CLIENT *client, int fua) {
+ssize_t rawexpwrite(off_t a, const char *buf, size_t len, CLIENT *client, int fua) {
 	int fhandle;
 	off_t foffset;
 	size_t maxbytes;
@@ -1263,7 +1263,7 @@ ssize_t rawexpwrite(off_t a, char *buf, size_t len, CLIENT *client, int fua) {
  * @param fua Flag to indicate 'Force Unit Access'
  * @return 0 on success, nonzero on failure
  **/
-int rawexpwrite_fully(off_t a, char *buf, size_t len, CLIENT *client, int fua) {
+int rawexpwrite_fully(off_t a, const char *buf, size_t len, CLIENT *client, int fua) {
 	ssize_t ret=0;
 
 	while(len > 0 && (ret=rawexpwrite(a, buf, len, client, fua)) > 0 ) {

--- a/nbd-server.c
+++ b/nbd-server.c
@@ -226,30 +226,25 @@ struct work_package {
 	void* data; /**< for write requests */
 };
 
-static volatile sig_atomic_t is_sigchld_caught; /**< Flag set by
-						     SIGCHLD handler
-						     to mark a child
-						     exit */
+/// Flag set by SIGCHLD handler to mark a child exit
+static volatile sig_atomic_t is_sigchld_caught;
 
-static volatile sig_atomic_t is_sigterm_caught; /**< Flag set by
-						     SIGTERM handler
-						     to mark a exit
-						     request */
+/// Flag set by SIGTERM handler to mark an exit request
+static volatile sig_atomic_t is_sigterm_caught;
 
-static volatile sig_atomic_t is_sighup_caught; /**< Flag set by SIGHUP
-                                                    handler to mark a
-                                                    reconfiguration
-                                                    request */
+/// Flag set by SIGHUP handler to mark a reconfiguration request
+static volatile sig_atomic_t is_sighup_caught;
 
-GArray* modernsocks;	  /**< Sockets for the modern handler. Not used
-			       if a client was only specified on the
-			       command line; only port used if
-			       oldstyle is set to false (and then the
-			       command-line client isn't used, gna gna).
-			       This may be more than one socket on
-			       systems that don't support serving IPv4
-			       and IPv6 from the same socket (like,
-			       e.g., FreeBSD) */
+/**
+ *  Sockets for the modern handler.
+ *  Not used if a client was only specified on the command line;
+ *  only port used if oldstyle is set to false (and then the command-line
+ *  client isn't used, gna gna).
+ *  This may be more than one socket on systems that don't support serving
+ *  IPv4 and IPv6 from the same socket (like, e.g., FreeBSD)
+ */
+GArray* modernsocks;
+
 GArray* childsocks;	/**< parent-side sockets for communication with children */
 int commsocket;		/**< child-side socket for communication with parent */
 static sem_t file_wait_sem;
@@ -262,7 +257,7 @@ bool logged_oversized=false;  /**< whether we logged oversized requests already 
 typedef enum {
 	PARAM_INT,		/**< This parameter is an integer */
 	PARAM_INT64,		/**< This parameter is an integer */
-	PARAM_STRING,		/**< This parameter is a string */
+    PARAM_STRING,	/**< This parameter is a string */
 	PARAM_BOOL,		/**< This parameter is a boolean */
 } PARAM_TYPE;
 
@@ -270,33 +265,30 @@ typedef enum {
  * Configuration file values
  **/
 typedef struct {
-	gchar *paramname;	/**< Name of the parameter, as it appears in
-				  the config file */
-	gboolean required;	/**< Whether this is a required (as opposed to
-				  optional) parameter */
+    gchar *paramname;   /**< Name of the parameter, as it appears in the config file */
+    gboolean required;	/**< Whether this is a required (as opposed to optional) parameter */
 	PARAM_TYPE ptype;	/**< Type of the parameter. */
 	gpointer target;	/**< Pointer to where the data of this
 				  parameter should be written. If ptype is
 				  PARAM_BOOL, the data is or'ed rather than
 				  overwritten. */
-	gint flagval;		/**< Flag mask for this parameter in case ptype
-				  is PARAM_BOOL. */
+    gint flagval;		/**< Flag mask for this parameter in case ptype is PARAM_BOOL. */
 } PARAM;
 
 /**
  * Configuration file values of the "generic" section
  **/
 struct generic_conf {
-        gchar *user;            /**< user we run the server as    */
-        gchar *group;           /**< group we run running as      */
-        gchar *modernaddr;      /**< address of the modern socket */
-        gchar *modernport;      /**< port of the modern socket    */
-        gchar *unixsock;	/**< file name of the unix domain socket */
+        gchar *user;        /**< user we run the server as    */
+        gchar *group;       /**< group we run running as      */
+        gchar *modernaddr;  /**< address of the modern socket */
+        gchar *modernport;  /**< port of the modern socket    */
+        gchar *unixsock;	   /**< file name of the unix domain socket */
 	gchar *certfile;        /**< certificate file             */
 	gchar *keyfile;         /**< key file                     */
 	gchar *cacertfile;      /**< CA certificate file          */
-	gchar *tlsprio;		/**< TLS priority string	  */
-        gint flags;             /**< global flags                 */
+    gchar *tlsprio;         /**< TLS priority string	  */
+        gint flags;         /**< global flags                 */
 	gint threads;		/**< maximum number of parallel threads we want to run */
 };
 

--- a/nbd-trdump.c
+++ b/nbd-trdump.c
@@ -8,7 +8,7 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
-#include <sys/time.h>
+// #include <sys/time.h>
 #include <sys/types.h>
 #include <stdint.h>
 #include <stdbool.h>

--- a/nbd-trplay.c
+++ b/nbd-trplay.c
@@ -9,10 +9,11 @@
  */
 
 #include <stdlib.h>
+#include <errno.h>
 #include <limits.h>
 #include <stdio.h>
 #include <string.h>
-#include <sys/time.h>
+// #include <sys/time.h>
 #include <sys/types.h>
 #include <fcntl.h>
 #include <stdint.h>

--- a/nbd.h
+++ b/nbd.h
@@ -15,7 +15,7 @@
 #ifndef LINUX_NBD_H
 #define LINUX_NBD_H
 
-//#include <linux/types.h>
+#include <stdint.h>
 
 #define NBD_SET_SOCK	_IO( 0xab, 0 )
 #define NBD_SET_BLKSIZE	_IO( 0xab, 1 )

--- a/nbdclt.h
+++ b/nbdclt.h
@@ -1,6 +1,9 @@
 #ifndef NBDCLT_H
 #define NBDCLT_H
 
+#include <stdint.h>
+#include <stdbool.h>
+
 typedef struct {
 	char *name;
 	char *dev;
@@ -23,7 +26,7 @@ typedef struct {
 	bool preinit;
 	bool force_ro;
 	bool tls;
-        bool persist_mode;
+    bool persist_mode;
 	char *priority;
 	int dead_conn_timeout;
 } CLIENT;

--- a/nbdsrv.c
+++ b/nbdsrv.c
@@ -272,18 +272,18 @@ int exptrim(struct nbd_request* req, CLIENT* client) {
 	assert(!(client->server->flags & F_READONLY));
 	assert(req->from + req->len <= client->exportsize);
 
-    /* For copy-on-write, we should trim on the diff file. Not yet implemented. */
+	/* For copy-on-write, we should trim on the diff file. Not yet implemented. */
 	if(client->server->flags & F_COPYONWRITE) {
 		DEBUG("TRIM not supported yet on copy-on-write exports");
 		return 0;
 	}
 	if (client->server->flags & F_TREEFILES) {
 		/* start address of first block to be trimmed */
-        off_t min = ( ( req->from + TREEPAGESIZE - 1 ) / TREEPAGESIZE) * TREEPAGESIZE;
+		off_t min = ( ( req->from + TREEPAGESIZE - 1 ) / TREEPAGESIZE) * TREEPAGESIZE;
 		/* start address of first block NOT to be trimmed */
-        const off_t max = ( ( req->from + req->len ) / TREEPAGESIZE) * TREEPAGESIZE;
+		const off_t max = ( ( req->from + req->len ) / TREEPAGESIZE) * TREEPAGESIZE;
 		while (min<max) {
-            delete_treefile(client->exportname, client->exportsize, min);
+			delete_treefile(client->exportname, client->exportsize, min);
 			min+=TREEPAGESIZE;
 		}
 		DEBUG("Performed TRIM request on TREE structure from %llu to %llu", (unsigned long long) req->from, (unsigned long long) req->len);

--- a/nbdsrv.c
+++ b/nbdsrv.c
@@ -1,12 +1,13 @@
 #include "config.h"
 #include "nbd-debug.h"
 
-#include <nbdsrv.h>
+#include "nbdsrv.h"
 
 #include <assert.h>
 #include <ctype.h>
 #include <netdb.h>
 #include <stdlib.h>
+#include <stdint.h>
 #include <stdio.h>
 #include <string.h>
 #include <syslog.h>
@@ -18,16 +19,17 @@
 #include <sys/socket.h>
 #include <treefiles.h>
 #include "backend.h"
+
 #ifdef HAVE_SYS_IOCTL_H
 #include <sys/ioctl.h>
 #endif
+
 #ifdef HAVE_SYS_MOUNT_H
 #include <sys/mount.h>
 #endif
 
-#define LINELEN 256	  /**< Size of static buffer used to read the
-			       authorization file (yuck) */
-#include <cliserv.h>
+#define LINELEN 256	  /**< Size of static buffer used to read the authorization file (yuck) */
+#include "cliserv.h"
 
 bool address_matches(const char* mask, const struct sockaddr* addr, GError** err) {
 	struct addrinfo *res, *aitmp, hints;
@@ -227,14 +229,12 @@ SERVER* dup_serve(const SERVER *const s) {
 }
 
 uint64_t size_autodetect(int fhandle) {
-	off_t es;
-	uint64_t bytes __attribute__((unused));
 	struct stat stat_buf;
-	int error;
 
 #ifdef HAVE_SYS_MOUNT_H
 #ifdef HAVE_SYS_IOCTL_H
 #ifdef BLKGETSIZE64
+    uint64_t bytes=0;
 	DEBUG("looking for export size with ioctl BLKGETSIZE64\n");
 	if (!ioctl(fhandle, BLKGETSIZE64, &bytes) && bytes) {
 		return bytes;
@@ -245,7 +245,7 @@ uint64_t size_autodetect(int fhandle) {
 
 	DEBUG("looking for fhandle size with fstat\n");
 	stat_buf.st_size = 0;
-	error = fstat(fhandle, &stat_buf);
+    const int error = fstat(fhandle, &stat_buf);
 	if (!error) {
 		/* always believe stat if a regular file as it might really
 		 * be zero length */
@@ -256,9 +256,9 @@ uint64_t size_autodetect(int fhandle) {
         }
 
 	DEBUG("looking for fhandle size with lseek SEEK_END\n");
-	es = lseek(fhandle, (off_t)0, SEEK_END);
-	if (es > ((off_t)0)) {
-		return (uint64_t)es;
+    const off_t es = lseek(fhandle, (off_t)0, SEEK_END);
+    if (es > 0) {
+        return es;
         } else {
                 DEBUG("lseek failed: %d", errno==EBADF?1:(errno==ESPIPE?2:(errno==EINVAL?3:4)));
         }
@@ -271,19 +271,19 @@ int exptrim(struct nbd_request* req, CLIENT* client) {
 	/* Caller did range checking */
 	assert(!(client->server->flags & F_READONLY));
 	assert(req->from + req->len <= client->exportsize);
-	/* For copy-on-write, we should trim on the diff file. Not yet
-	 * implemented. */
+
+    /* For copy-on-write, we should trim on the diff file. Not yet implemented. */
 	if(client->server->flags & F_COPYONWRITE) {
 		DEBUG("TRIM not supported yet on copy-on-write exports");
 		return 0;
 	}
 	if (client->server->flags & F_TREEFILES) {
 		/* start address of first block to be trimmed */
-		off_t min = ( ( req->from + TREEPAGESIZE - 1 ) / TREEPAGESIZE) * TREEPAGESIZE;
+        off_t min = ( ( req->from + TREEPAGESIZE - 1 ) / TREEPAGESIZE) * TREEPAGESIZE;
 		/* start address of first block NOT to be trimmed */
-		off_t max = ( ( req->from + req->len ) / TREEPAGESIZE) * TREEPAGESIZE;
+        const off_t max = ( ( req->from + req->len ) / TREEPAGESIZE) * TREEPAGESIZE;
 		while (min<max) {
-			delete_treefile(client->exportname,client->exportsize,min);
+            delete_treefile(client->exportname, client->exportsize, min);
 			min+=TREEPAGESIZE;
 		}
 		DEBUG("Performed TRIM request on TREE structure from %llu to %llu", (unsigned long long) req->from, (unsigned long long) req->len);

--- a/nbdsrv.h
+++ b/nbdsrv.h
@@ -1,11 +1,12 @@
 #ifndef NBDSRV_H
 #define NBDSRV_H
 
-#include "lfs.h"
+// #include "lfs.h"
 
 #include <glib.h>
 #include <stdbool.h>
 #include <stdint.h>
+#include <pthread.h>
 
 #include <sys/socket.h>
 #include <sys/types.h>

--- a/treefiles.c
+++ b/treefiles.c
@@ -1,10 +1,11 @@
+#include <errno.h>
 #include <fcntl.h>
 #include <limits.h> // for PATH_MAX
 #include <inttypes.h>
 #include <stdio.h>
 #include <unistd.h>
 #include <sys/stat.h>
-#include <sys/types.h>
+// #include <sys/types.h>
 
 #include "config.h"
 #include "cliserv.h"

--- a/treefiles.c
+++ b/treefiles.c
@@ -34,18 +34,18 @@ void construct_path(char* name, int lenmax, off_t size, off_t pos, off_t* ppos) 
 	}
 }
 
-void delete_treefile(const char* base_nme, off_t export_size, off_t pos) {
+void delete_treefile(const char* export_name, off_t export_size, off_t pos) {
 	char filename[PATH_MAX];
 	off_t ppos;
 
-    strncpy(filename,base_nme,PATH_MAX-1);
+    strncpy(filename, export_name, PATH_MAX-1);
 	filename[PATH_MAX-1] = '\0';
-    construct_path(filename+strlen(base_nme), PATH_MAX-strlen(base_nme)-1, export_size, pos, &ppos);
+    construct_path(filename+strlen(export_name), PATH_MAX-strlen(export_name)-1, export_size, pos, &ppos);
 
-	DEBUG("Deleting treefile: %s",filename);
+	DEBUG("Deleting treefile: %s", filename);
 
 	if (unlink(filename)==-1)
-		DEBUG("Deleting failed : %s",strerror(errno));
+		DEBUG("Deleting failed : %s", strerror(errno));
 }
 
 void mkdir_path(char* path) {
@@ -61,13 +61,13 @@ void mkdir_path(char* path) {
 	}
 }
 
-int open_treefile(char* name, mode_t mode, off_t size, off_t pos, pthread_mutex_t* mutex) {
+int open_treefile(const char* export_name, mode_t mode, off_t export_size, off_t pos, pthread_mutex_t* mutex) {
 	char filename[PATH_MAX];
 	off_t ppos;
 
-	strncpy(filename,name,PATH_MAX-1);
+	strncpy(filename, export_name, PATH_MAX-1);
 	filename[PATH_MAX - 1] = '\0';
-	construct_path(filename+strlen(name),PATH_MAX-strlen(name)-1,size,pos,&ppos);
+	construct_path(filename+strlen(export_name), PATH_MAX-strlen(export_name)-1, export_size, pos, &ppos);
 
 	DEBUG("Accessing treefile %s (offset %llu of %llu)",filename,(unsigned long long)pos,(unsigned long long)size);
 

--- a/treefiles.c
+++ b/treefiles.c
@@ -12,6 +12,8 @@
 #include "treefiles.h"
 #include "nbd-debug.h"
 
+#include <string.h>
+
 /**
  * Tree structure helper functions
  */
@@ -32,13 +34,13 @@ void construct_path(char* name, int lenmax, off_t size, off_t pos, off_t* ppos) 
 	}
 }
 
-void delete_treefile(char* name, off_t size, off_t pos) {
+void delete_treefile(const char* base_nme, off_t export_size, off_t pos) {
 	char filename[PATH_MAX];
 	off_t ppos;
 
-	strncpy(filename,name,PATH_MAX-1);
+    strncpy(filename,base_nme,PATH_MAX-1);
 	filename[PATH_MAX-1] = '\0';
-	construct_path(filename+strlen(name),PATH_MAX-strlen(name)-1,size,pos,&ppos);
+    construct_path(filename+strlen(base_nme), PATH_MAX-strlen(base_nme)-1, export_size, pos, &ppos);
 
 	DEBUG("Deleting treefile: %s",filename);
 

--- a/treefiles.h
+++ b/treefiles.h
@@ -13,6 +13,6 @@ void delete_treefile(const char *base_name, off_t export_size, off_t pos);
 
 void mkdir_path(char *path);
 
-int open_treefile(char *name, mode_t mode, off_t size, off_t pos, pthread_mutex_t *mutex);
+int open_treefile(const char *export_name, mode_t mode, off_t size, off_t pos, pthread_mutex_t *mutex);
 
 #endif

--- a/treefiles.h
+++ b/treefiles.h
@@ -7,9 +7,12 @@
 #define TREEDIRSIZE  1024 /**< number of files per subdirectory (or subdirs per subdirectory) */
 #define TREEPAGESIZE 4096 /**< tree (block) files uses those chunks */
 
-void construct_path(char *name, int lenmax, off_t size, off_t pos, off_t *ppos);
-void delete_treefile(char *name, off_t size, off_t pos);
+void construct_path(char *name, int lenmax, off_t export_size, off_t pos, off_t *ppos);
+
+void delete_treefile(const char *base_name, off_t export_size, off_t pos);
+
 void mkdir_path(char *path);
+
 int open_treefile(char *name, mode_t mode, off_t size, off_t pos, pthread_mutex_t *mutex);
 
 #endif


### PR DESCRIPTION
My IDE QtCreator complains about unnecessary `#include` directives or `#include`s in .h files whose declarations are only used/needed in certain .c files, not in the header itself.

So tried to fix these complains until it "works on my machine". But I cannot speak for other systems or configurations. That's why I only commented-out the removed #include directives so far, instead of removing them completely.

If these changes work on all supported & tested platforms I'd remove the `// #include` lines. :-)
