### PR TITLE
Fix ExecStop command in nbd@.service.sh.in

### DIFF
--- a/systemd/nbd@.service.sh.in
+++ b/systemd/nbd@.service.sh.in
@@ -17,7 +17,7 @@ DefaultDependencies=no
 Type=oneshot
 RemainAfterExit=yes
 ExecStart=@sbindir@/nbd-client %i
-ExecStop=@sbindir@/nbd-client -d /dev/%i
+ExecStop=@sbindir@/nbd-client -d %i
 [Install]
 RequiredBy=dev-%i.device
 RequiredBy=dev-%ip1.device


### PR DESCRIPTION
Passing the device path results in an error:

```
nbd-client -d /dev/nbd0 
Error: Invalid nbd device target

Exiting.
```

Therefore, don't pass the full device path, which is also consistent with how `ExecStart` uses `nbd-client`.